### PR TITLE
Fix: Protected var $view error

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -14,14 +14,14 @@ $app = new \Slim\Slim(array(
 
 // Prepare view
 $app->view(new \Slim\Views\Twig());
-$app->view->parserOptions = array(
+$app->view()->parserOptions = array(
     'charset' => 'utf-8',
     'cache' => realpath('../templates/cache'),
     'auto_reload' => true,
     'strict_variables' => false,
     'autoescape' => true
 );
-$app->view->parserExtensions = array(new \Slim\Views\TwigExtension());
+$app->view()->parserExtensions = array(new \Slim\Views\TwigExtension());
 
 // Define routes
 $app->get('/', function () use ($app) {


### PR DESCRIPTION
Running the default install of Slim-Skeleton from composer via the PHP5.4 built in web-server generates the following error:

```
Fatal error: Cannot access protected property Slim\Slim::$view in public/index.php on line 17 Call Stack: 0.0004 239656 1. {main}() public/index.php:0 
```

I don't know slim massively well, but I know the 2.3 upgrade introduced a DI container, and I'm guessing (it is just a guess) it's at this point that `$view` became private (as I never had a problem with the 2.2 skeleton).

Inspecting the source showed that the `view()` method used on line 16 will return the view if nothing is passed to it, so I replaced both calls to `$app->view` in `index.php` with a call to `$app->view()` instead, and this seemed to work as expected!
