### PR TITLE
Updated script with regex to support more files.

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,7 @@
 if (PHP_SAPI == 'cli-server') {
     // To help the built-in PHP dev server, check if the request was actually for
     // something which should probably be served as a static file
-    $file = __DIR__ . $_SERVER['REQUEST_URI'];
+    $file = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
     if (is_file($file)) {
         return false;
     }


### PR DESCRIPTION
The reason I updated the script was to handle special cases. For example, here are a few files that failed to pass whether or not it was a file or not - https://3v4l.org/dqnRF 

Taken from Silex - http://silex.sensiolabs.org/doc/web_servers.html#php-5-4

Fixes the following issue: https://github.com/slimphp/Slim-Skeleton/issues/29

Thanks!