### PR TITLE
Set addContentLengthHeader to false

### DIFF
--- a/src/settings.php
+++ b/src/settings.php
@@ -2,6 +2,7 @@
 return [
     'settings' => [
         'displayErrorDetails' => true, // set to false in production
+        'addContentLengthHeader' => false, // Allow the web server to send the content-length header
 
         // Renderer settings
         'renderer' => [


### PR DESCRIPTION
False is the correct setting, but it defaults to true for legacy reasons. When set to false, we let the web browser set the content length header and so tools like RunScope work.