### PR TITLE
Allow phpunit v4.8 and above for compatibility with PHP 5.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "monolog/monolog": "^1.17"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.4"
+        "phpunit/phpunit": ">=4.8 < 6.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
This fixes the compatibility issue mentioned by @oanhnn in #35

Composer was set to require phpunit 5.4 and above, but phpunit 5.4 only supports PHP 5.6+, but Slim 3 support PHP 5.5. The test examples are compatible with phpunit v4, so I have altered `composer.json` to use the maximum possible version between 4.8 and 6.