### PR TITLE
Pass settings array, not arguments for container when constructing Application

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -15,7 +15,7 @@ session_start();
 
 // Instantiate the app
 $settings = require __DIR__ . '/../src/settings.php';
-$app = new \Slim\App($settings);
+$app = new \Slim\App(['settings' => $settings]);
 
 // Set up dependencies
 require __DIR__ . '/../src/dependencies.php';

--- a/src/settings.php
+++ b/src/settings.php
@@ -1,19 +1,17 @@
 <?php
 return [
-    'settings' => [
-        'displayErrorDetails' => true, // set to false in production
-        'addContentLengthHeader' => false, // Allow the web server to send the content-length header
+    'displayErrorDetails' => true, // set to false in production
+    'addContentLengthHeader' => false, // Allow the web server to send the content-length header
 
-        // Renderer settings
-        'renderer' => [
-            'template_path' => __DIR__ . '/../templates/',
-        ],
+    // Renderer settings
+    'renderer' => [
+        'template_path' => __DIR__ . '/../templates/',
+    ],
 
-        // Monolog settings
-        'logger' => [
-            'name' => 'slim-app',
-            'path' => __DIR__ . '/../logs/app.log',
-            'level' => \Monolog\Logger::DEBUG,
-        ],
+    // Monolog settings
+    'logger' => [
+        'name' => 'slim-app',
+        'path' => __DIR__ . '/../logs/app.log',
+        'level' => \Monolog\Logger::DEBUG,
     ],
 ];

--- a/tests/functional/BaseTestCase.php
+++ b/tests/functional/BaseTestCase.php
@@ -55,7 +55,7 @@ class BaseTestCase extends \PHPUnit_Framework_TestCase
         $settings = require __DIR__ . '/../../src/settings.php';
 
         // Instantiate the application
-        $app = new App($settings);
+        $app = new App(['settings' => $settings]);
 
         // Set up dependencies
         require __DIR__ . '/../../src/dependencies.php';


### PR DESCRIPTION
At this moment settings.php doesn't really contain application settings, but whole container.

This PR fixes it by initializing application with explicit array with `settings` property.