### PR TITLE
Adding docker with docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+
+volumes:
+    logs:
+        driver: local
+
+services:
+    slim:
+        image: php:7-alpine
+        working_dir: /var/www
+        command: php -S 0.0.0.0:8080 -t public public/index.php
+        environment:
+            docker: "true"
+        ports:
+            - 8080:8080
+        volumes:
+            - .:/var/www
+            - logs:/var/www/logs

--- a/src/settings.php
+++ b/src/settings.php
@@ -12,7 +12,7 @@ return [
         // Monolog settings
         'logger' => [
             'name' => 'slim-app',
-            'path' => __DIR__ . '/../logs/app.log',
+            'path' => isset($_ENV['docker']) ? 'php://stdout' : __DIR__ . '/../logs/app.log',
             'level' => \Monolog\Logger::DEBUG,
         ],
     ],


### PR DESCRIPTION
* Added docker-compose.yml with default runtime, php:7-alpine
* Allowing logging to stdout to be toggled with environment switch: docker.
    This better suits docker workflow and allows docker-compose to capture the logging to the consol