### PR TITLE
fix filename routing of the builtin php server

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 if (PHP_SAPI == 'cli-server') {
+    // Set the index file script to index.php
+    $_SERVER['SCRIPT_NAME'] = basename(__FILE__);
     // To help the built-in PHP dev server, check if the request was actually for
     // something which should probably be served as a static file
     $url  = parse_url($_SERVER['REQUEST_URI']);


### PR DESCRIPTION
I had a problem with the php buildin webserver 
to find correct routes when having a filename.

reproduce: browse to the example and type:
- `localhost:8080/tom` => `Hello tom!` ( SCRIPT_NAME = /index.php )
- `localhost:8080/tom.doe` => ` ` ( SCRIPT_NAME = /tom.doe )
- `localhost:8080/tom.doe/wtf` => ` ` (is also handled, no 404) ( SCRIPT_NAME = /tom.doe/wtf )

setting `$_SERVER['SCRIPT_NAME'] = '/index.php'` solves this issue
