### PR TITLE
Bind to localhost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "process-timeout" : 0
     },
     "scripts": {
-        "start": "php -S 0.0.0.0:8080 -t public public/index.php",
+        "start": "php -S localhost:8080 -t public public/index.php",
         "test": "phpunit"
     }
 


### PR DESCRIPTION
If you bind to 0.0.0.0, then it's world accessible, so better practice is to just bind locally.

Closes https://github.com/slimphp/Slim/issues/2074.