### PR TITLE
Improve REAME.md for dummy users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Replace `[my-app-name]` with the desired directory name for your new application
 * Point your virtual host document root to your new application's `public/` directory.
 * Ensure `logs/` is web writeable.
 
-To run the application in development, you can also run this command. 
+To run the application in development, you can run these commands 
 
+	cd [my-app-name]
 	php composer.phar start
 
-Run this command to run the test suite
+Run this command in the application directory to run the test suite
 
 	php composer.phar test
 


### PR DESCRIPTION
Include the cd command to change into the application directory. Mention the application directory explicitly. Avoids some early frustrations for newbie users.