### PR TITLE
Remove public from running built-in server as this is not necessary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "process-timeout" : 0
     },
     "scripts": {
-        "start": "php -S localhost:8080 -t public public/index.php",
+        "start": "php -S localhost:8080 -t public index.php",
         "test": "phpunit"
     }
 


### PR DESCRIPTION
We can remove `public` from running the built-in server in composer.json