### PR TITLE
🚑 Drop index.php from php internal server command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     slim:
         image: php:7-alpine
         working_dir: /var/www
-        command: php -S 0.0.0.0:8080 -t public index.php
+        command: php -S 0.0.0.0:8080 -t public
         environment:
             docker: "true"
         ports:


### PR DESCRIPTION
Resolves #84 where some Docker users are running into issues with the internal PHP server not serving the site properly