### PR TITLE
Update version of PHPUnit to the minimum supported version along with PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0",
         "slim/slim": "^3.1",
         "slim/php-view": "^2.0",
         "monolog/monolog": "^1.17"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8 < 6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -6,6 +6,7 @@ use Slim\App;
 use Slim\Http\Request;
 use Slim\Http\Response;
 use Slim\Http\Environment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * This is an example class that shows how you could set up a method that
@@ -13,7 +14,7 @@ use Slim\Http\Environment;
  * tuned to the specifics of this skeleton app, so if your needs are
  * different, you'll need to change it.
  */
-class BaseTestCase extends \PHPUnit_Framework_TestCase
+class BaseTestCase extends TestCase
 {
     /**
      * Use middleware when running application?


### PR DESCRIPTION
Update version of PHPUnit to the minimum supported version along with the minimum required PHP version.

PHPUnit announced that they would be dropping support and no longer providing bugfixes for anything less than version 6 as of February 2, 2018. PHPUnit Version 6+ also has a PHP requirement of PHP 7.0+