### PR TITLE
Fix deprecated methods on HomepageTest

### DIFF
--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -12,8 +12,8 @@ class HomepageTest extends BaseTestCase
         $response = $this->runApp('GET', '/');
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('SlimFramework', (string)$response->getBody());
-        $this->assertNotContains('Hello', (string)$response->getBody());
+        $this->assertStringContainsString('SlimFramework', (string)$response->getBody());
+        $this->assertStringNotContainsString('Hello', (string)$response->getBody());
     }
 
     /**
@@ -24,7 +24,7 @@ class HomepageTest extends BaseTestCase
         $response = $this->runApp('GET', '/name');
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('Hello name!', (string)$response->getBody());
+        $this->assertStringContainsString('Hello name!', (string)$response->getBody());
     }
 
     /**
@@ -35,6 +35,6 @@ class HomepageTest extends BaseTestCase
         $response = $this->runApp('POST', '/', ['test']);
 
         $this->assertEquals(405, $response->getStatusCode());
-        $this->assertContains('Method not allowed', (string)$response->getBody());
+        $this->assertStringContainsString('Method not allowed', (string)$response->getBody());
     }
 }


### PR DESCRIPTION
When running phpunit just after the install of Slim-Skeleton I'm receiving some warnings from phpunit about the methods `assertContains` and `assertNotContains` that will be deprecated in PHPUnit 9.

Issue:
![DeepinScreenshot_sun-awt-X11-XFramePeer_20190430230946](https://user-images.githubusercontent.com/30262837/57003559-fc649b00-6b9d-11e9-8e1b-77fb669ac263.png)

This PR aims to fix the issue with those methods.

Fix:
![DeepinScreenshot_sun-awt-X11-XFramePeer_20190430231342](https://user-images.githubusercontent.com/30262837/57003569-0c7c7a80-6b9e-11e9-97aa-fcd7be1d2b37.png)

