### PR TITLE
Ensure json content type for error responses

### DIFF
--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -64,6 +64,6 @@ class HttpErrorHandler extends SlimErrorHandler
         $response = $this->responseFactory->createResponse($statusCode);
         $response->getBody()->write($encodedPayload);
 
-        return $response;
+        return $response->withHeader('Content-Type', 'application/json');
     }
 }


### PR DESCRIPTION
Errors are currently being served with a content type of text/html.