### PR TITLE
Use PHP-DI ContainerBuilder over direct Container manipulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor/
 /logs/*
 !/logs/README.md
+/var/cache/*

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -2,28 +2,27 @@
 declare(strict_types=1);
 
 use DI\Container;
+use DI\ContainerBuilder;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\UidProcessor;
 use Psr\Log\LoggerInterface;
-use Slim\App;
 
-return function (App $app) {
-    /** @var Container $container */
-    $container = $app->getContainer();
+return function (ContainerBuilder $containerBuilder) {
+    $containerBuilder->addDefinitions([
+        LoggerInterface::class => function (Container $c) {
+            $settings = $c->get('settings');
 
-    $container->set(LoggerInterface::class, function (Container $c) {
-        $settings = $c->get('settings');
+            $loggerSettings = $settings['logger'];
+            $logger = new Logger($loggerSettings['name']);
 
-        $loggerSettings = $settings['logger'];
-        $logger = new Logger($loggerSettings['name']);
+            $processor = new UidProcessor();
+            $logger->pushProcessor($processor);
 
-        $processor = new UidProcessor();
-        $logger->pushProcessor($processor);
+            $handler = new StreamHandler($loggerSettings['path'], $loggerSettings['level']);
+            $logger->pushHandler($handler);
 
-        $handler = new StreamHandler($loggerSettings['path'], $loggerSettings['level']);
-        $logger->pushHandler($handler);
-
-        return $logger;
-    });
+            return $logger;
+        },
+    ]);
 };

--- a/app/repositories.php
+++ b/app/repositories.php
@@ -7,7 +7,7 @@ use DI\ContainerBuilder;
 
 return function (ContainerBuilder $containerBuilder) {
     // Here we map our UserRepository interface to its in memory implementation
-	$containerBuilder->addDefinitions([
-		UserRepository::class => \DI\autowire(InMemoryUserRepository::class),
-	]);
+    $containerBuilder->addDefinitions([
+        UserRepository::class => \DI\autowire(InMemoryUserRepository::class),
+    ]);
 };

--- a/app/repositories.php
+++ b/app/repositories.php
@@ -3,13 +3,11 @@ declare(strict_types=1);
 
 use App\Domain\User\UserRepository;
 use App\Infrastructure\Persistence\User\InMemoryUserRepository;
-use DI\Container;
-use Slim\App;
+use DI\ContainerBuilder;
 
-return function (App $app) {
-    /** @var Container $container */
-    $container = $app->getContainer();
-
+return function (ContainerBuilder $containerBuilder) {
     // Here we map our UserRepository interface to its in memory implementation
-    $container->set(UserRepository::class, \DI\autowire(InMemoryUserRepository::class));
+	$containerBuilder->addDefinitions([
+		UserRepository::class => \DI\autowire(InMemoryUserRepository::class),
+	]);
 };

--- a/app/settings.php
+++ b/app/settings.php
@@ -1,21 +1,19 @@
 <?php
 declare(strict_types=1);
 
-use DI\Container;
+use DI\ContainerBuilder;
 use Monolog\Logger;
-use Slim\App;
 
-return function (App $app) {
-    /** @var Container $container */
-    $container = $app->getContainer();
-
+return function (ContainerBuilder $containerBuilder) {
     // Global Settings Object
-    $container->set('settings', [
-        'displayErrorDetails' => true, // Should be set to false in production
-        'logger' => [
-            'name' => 'slim-app',
-            'path' => isset($_ENV['docker']) ? 'php://stdout' : __DIR__ . '/../logs/app.log',
-            'level' => Logger::DEBUG,
+    $containerBuilder->addDefinitions([
+        'settings' => [
+            'displayErrorDetails' => true, // Should be set to false in production
+            'logger' => [
+                'name' => 'slim-app',
+                'path' => isset($_ENV['docker']) ? 'php://stdout' : __DIR__ . '/../logs/app.log',
+                'level' => Logger::DEBUG,
+            ],
         ],
     ]);
 };

--- a/public/index.php
+++ b/public/index.php
@@ -4,35 +4,42 @@ declare(strict_types=1);
 use App\Application\Handlers\HttpErrorHandler;
 use App\Application\Handlers\ShutdownHandler;
 use App\Application\ResponseEmitter\ResponseEmitter;
-use DI\Container;
+use DI\ContainerBuilder;
 use Slim\Factory\AppFactory;
 use Slim\Factory\ServerRequestCreatorFactory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// Instantiate PHP-DI Container
-$container = new Container();
+// Instantiate PHP-DI ContainerBuilder
+$containerBuilder = new ContainerBuilder();
+
+if (false) { // Should be set to true in production
+	$containerBuilder->enableCompilation(__DIR__ . '/../var/cache');
+}
+
+// Set up settings
+$settings = require __DIR__ . '/../app/settings.php';
+$settings($containerBuilder);
+
+// Set up dependencies
+$dependencies = require __DIR__ . '/../app/dependencies.php';
+$dependencies($containerBuilder);
+
+// Set up repositories
+$repositories = require __DIR__ . '/../app/repositories.php';
+$repositories($containerBuilder);
+
+// Build PHP-DI Container instance
+$container = $containerBuilder->build();
 
 // Instantiate the app
 AppFactory::setContainer($container);
 $app = AppFactory::create();
 $callableResolver = $app->getCallableResolver();
 
-// Set up settings
-$settings = require __DIR__ . '/../app/settings.php';
-$settings($app);
-
-// Set up dependencies
-$dependencies = require __DIR__ . '/../app/dependencies.php';
-$dependencies($app);
-
 // Register middleware
 $middleware = require __DIR__ . '/../app/middleware.php';
 $middleware($app);
-
-// Set up repositories
-$repositories = require __DIR__ . '/../app/repositories.php';
-$repositories($app);
 
 // Register routes
 $routes = require __DIR__ . '/../app/routes.php';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use DI\Container;
+use DI\ContainerBuilder;
 use Exception;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -22,28 +22,33 @@ class TestCase extends PHPUnit_TestCase
      */
     protected function getAppInstance(): App
     {
-        // Instantiate PHP-DI Container
-        $container = new Container();
+        // Instantiate PHP-DI ContainerBuilder
+        $containerBuilder = new ContainerBuilder();
+
+        // Container intentionally not compiled for tests.
+
+        // Set up settings
+        $settings = require __DIR__ . '/../app/settings.php';
+        $settings($containerBuilder);
+
+        // Set up dependencies
+        $dependencies = require __DIR__ . '/../app/dependencies.php';
+        $dependencies($containerBuilder);
+
+        // Set up repositories
+        $repositories = require __DIR__ . '/../app/repositories.php';
+        $repositories($containerBuilder);
+
+        // Build PHP-DI Container instance
+        $container = $containerBuilder->build();
 
         // Instantiate the app
         AppFactory::setContainer($container);
         $app = AppFactory::create();
 
-        // Set up settings
-        $settings = require __DIR__ . '/../app/settings.php';
-        $settings($app);
-
-        // Set up dependencies
-        $dependencies = require __DIR__ . '/../app/dependencies.php';
-        $dependencies($app);
-
         // Register middleware
         $middleware = require __DIR__ . '/../app/middleware.php';
         $middleware($app);
-
-        // Set up repositories
-        $repositories = require __DIR__ . '/../app/repositories.php';
-        $repositories($app);
 
         // Register routes
         $routes = require __DIR__ . '/../app/routes.php';


### PR DESCRIPTION
Addresses #112.

* Uses ContainerBuilder instead of instantiating Container instance directly
* Refactors settings, dependencies and repositories callbacks to set definitions on ContainerBuilder
* Conditionally enables container compilation

A couple of questions:

https://github.com/ssnepenthe/Slim-Skeleton/blob/f5b5fcf201fb0840820117927105b394a06e53e7/public/index.php#L16

What should the condition for enabling container compilation be? I tend to do something like `'development' !== getenv('APP_ENVIRONMENT')`, but for this PR I tried to stick to the behavior already seen for the `displayErrorDetails` setting and allow individual users to define their own condition.

https://github.com/ssnepenthe/Slim-Skeleton/blob/f5b5fcf201fb0840820117927105b394a06e53e7/public/index.php#L17

Where should the compiled container be saved? I only used `var/cache` since that is what is used in the PHP-DI docs.

