### PR TITLE
Change PHP-DI factory type hints from Container to ContainerInterface

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -1,16 +1,16 @@
 <?php
 declare(strict_types=1);
 
-use DI\Container;
 use DI\ContainerBuilder;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\UidProcessor;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 return function (ContainerBuilder $containerBuilder) {
     $containerBuilder->addDefinitions([
-        LoggerInterface::class => function (Container $c) {
+        LoggerInterface::class => function (ContainerInterface $c) {
             $settings = $c->get('settings');
 
             $loggerSettings = $settings['logger'];


### PR DESCRIPTION
Sorry - I should have included this in the previous PR.

From the [docs](http://php-di.org/doc/php-definitions.html#factories):

> When injecting the container, you should type-hint against the interface Psr\Container\ContainerInterface instead of the implementation DI\Container.