### PR TITLE
FIX check if there is a buffer before cleaning it.

### DIFF
--- a/src/Application/ResponseEmitter/ResponseEmitter.php
+++ b/src/Application/ResponseEmitter/ResponseEmitter.php
@@ -25,7 +25,10 @@ class ResponseEmitter extends SlimResponseEmitter
             ->withAddedHeader('Cache-Control', 'post-check=0, pre-check=0')
             ->withHeader('Pragma', 'no-cache');
 
-        ob_clean();
+        if (ob_get_contents()) {
+            ob_clean();
+        }
+
         parent::emit($response);
     }
 }


### PR DESCRIPTION
I was getting the following error

```
{
    "statusCode": 500,
    "error": {
        "type": "SERVER_ERROR",
        "description": "ERROR: ob_clean(): failed to delete buffer. No buffer to delete on line 28 in file \/var\/www\/src\/Application\/ResponseEmitter\/ResponseEmitter.php."
    }
}
```

Which I thought was strange. This PR fixes it though.