### PR TITLE
remove unused $app->getContainer() in routes

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -9,14 +9,12 @@ use Slim\App;
 use Slim\Interfaces\RouteCollectorProxyInterface as Group;
 
 return function (App $app) {
-    $container = $app->getContainer();
-
     $app->get('/', function (Request $request, Response $response) {
         $response->getBody()->write('Hello world!');
         return $response;
     });
 
-    $app->group('/users', function (Group $group) use ($container) {
+    $app->group('/users', function (Group $group) {
         $group->get('', ListUsersAction::class);
         $group->get('/{id}', ViewUserAction::class);
     });


### PR DESCRIPTION
DI container instance accessible inside of the Closure via the `$this` keyword