### PR TITLE
Fix Slim\Psr7\Request instantiation

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -81,6 +81,6 @@ class TestCase extends PHPUnit_TestCase
             $h->addHeader($name, $value);
         }
 
-        return new SlimRequest($method, $uri, $h, $serverParams, $cookies, $stream);
+        return new SlimRequest($method, $uri, $h, $cookies, $serverParams, $stream);
     }
 }


### PR DESCRIPTION
This is how `SlimRequest` (`Slim\Psr7\Request`) is currently instantiated:
```php
new SlimRequest($method, $uri, $h, $serverParams, $cookies, $stream)
```

And this is what `Slim\Psr7\Request` actually expects:
```php
public function __construct(
        $method,
        UriInterface $uri,
        HeadersInterface $headers,
        array $cookies,      👈
        array $serverParams, 👈
        StreamInterface $body,
        array $uploadedFiles = []
    )
```

The proposed change swaps the order in which `$cookies` and `$serverParams` are passed to `Request`, so that it’s instantiated correctly.