### PR TITLE
create var/cache directory with .gitignore in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /vendor/
 /logs/*
 !/logs/README.md
-/var/cache/*

--- a/var/cache/.gitignore
+++ b/var/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
so user doesn't need to manually create `var/cache` directory when activating cache, eg, activating cache like in https://github.com/slimphp/Slim-Skeleton/blob/master/public/index.php#L17