### PR TITLE
add missing call to ob_clean

### DIFF
--- a/src/Application/Handlers/ShutdownHandler.php
+++ b/src/Application/Handlers/ShutdownHandler.php
@@ -76,6 +76,7 @@ class ShutdownHandler
             $exception = new HttpInternalServerErrorException($this->request, $message);
             $response = $this->errorHandler->__invoke($this->request, $exception, $this->displayErrorDetails, false, false);
 
+            ob_clean();
             $responseEmitter = new ResponseEmitter();
             $responseEmitter->emit($response);
         }


### PR DESCRIPTION
Fix #134.

This PR just add a missing call to ``ob_clean``, like showed in [Advanced Shutdown Handler](http://www.slimframework.com/docs/v4/objects/application.html#notices-and-warnings-handling) of the documentation.

