### PR TITLE
Add CORS OPTIONS handler

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -9,6 +9,11 @@ use Slim\App;
 use Slim\Interfaces\RouteCollectorProxyInterface as Group;
 
 return function (App $app) {
+    $app->options('/{routes:.+}', function (Request $request, Response $response) {
+        // CORS Pre-Flight OPTIONS Request Handler
+        return $response;
+    });
+
     $app->get('/', function (Request $request, Response $response) {
         $response->getBody()->write('Hello world!');
         return $response;


### PR DESCRIPTION
As pointed out in #140 the pre-flight requests fail as there's no route to handle the `OPTIONS` method. The `ResponseEmitter` already has the CORS headers https://github.com/slimphp/Slim-Skeleton/blob/master/src/Application/ResponseEmitter/ResponseEmitter.php#L19