### PR TITLE
Add new test to find all users by default

### DIFF
--- a/tests/Infrastructure/Persistence/User/InMemoryUserRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/User/InMemoryUserRepositoryTest.php
@@ -19,6 +19,21 @@ class InMemoryUserRepositoryTest extends TestCase
         $this->assertEquals([$user], $userRepository->findAll());
     }
 
+    public function testFindAllUsersByDefault()
+    {
+        $users = [
+            1 => new User(1, 'bill.gates', 'Bill', 'Gates'),
+            2 => new User(2, 'steve.jobs', 'Steve', 'Jobs'),
+            3 => new User(3, 'mark.zuckerberg', 'Mark', 'Zuckerberg'),
+            4 => new User(4, 'evan.spiegel', 'Evan', 'Spiegel'),
+            5 => new User(5, 'jack.dorsey', 'Jack', 'Dorsey'),
+        ];
+
+        $userRepository = new InMemoryUserRepository();
+
+        $this->assertEquals(array_values($users), $userRepository->findAll());
+    }
+
     public function testFindUserOfId()
     {
         $user = new User(1, 'bill.gates', 'Bill', 'Gates');


### PR DESCRIPTION
Add unit test to cover findAll function, for the case when calling the InMemoryUserRepository constructor passing $users with null value.
