### PR TITLE
fix: correct cors route regex

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -9,7 +9,7 @@ use Slim\App;
 use Slim\Interfaces\RouteCollectorProxyInterface as Group;
 
 return function (App $app) {
-    $app->options('/{routes:.+}', function (Request $request, Response $response) {
+    $app->options('/{routes:.*}', function (Request $request, Response $response) {
         // CORS Pre-Flight OPTIONS Request Handler
         return $response;
     });


### PR DESCRIPTION
Previous will not match to the root of a domain, since the pattern is
configured to look for one or more characters after the /, whereas it
should be zero or more.

Example of previous, broken regex: https://regex101.com/r/F7HTMT/1
Example of fixed, new regex: https://regex101.com/r/unu0lu/1