### PR TITLE
Use the code passed to ActionPayload for the HTTP status code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
+.vscode/
 /coverage/
 /vendor/
 /logs/*
 !/logs/README.md
+.phpunit.result.cache

--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -115,6 +115,9 @@ abstract class Action
     {
         $json = json_encode($payload, JSON_PRETTY_PRINT);
         $this->response->getBody()->write($json);
-        return $this->response->withHeader('Content-Type', 'application/json');
+
+        return $this->response
+                    ->withHeader('Content-Type', 'application/json')
+                    ->withStatus($payload->getStatusCode());
     }
 }

--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -101,9 +101,10 @@ abstract class Action
      * @param  array|object|null $data
      * @return Response
      */
-    protected function respondWithData($data = null): Response
+    protected function respondWithData($data = null, int $statusCode = 200): Response
     {
-        $payload = new ActionPayload(200, $data);
+        $payload = new ActionPayload($statusCode, $data);
+
         return $this->respond($payload);
     }
 

--- a/tests/Application/Actions/ActionTest.php
+++ b/tests/Application/Actions/ActionTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Application\Actions;
+
+use App\Application\Actions\Action;
+use App\Application\Actions\ActionPayload;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Log\LoggerInterface;
+use Tests\TestCase;
+
+class ActionTest extends TestCase
+{
+    public function testActionSetsHttpCodeInRespond()
+    {
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+        $logger = $container->get(LoggerInterface::class);
+
+        $testAction = new class($logger) extends Action {
+            public function __construct(
+                LoggerInterface $loggerInterface
+            ) {
+                parent::__construct($loggerInterface);
+            }
+
+            public function action() :Response
+            {
+                return $this->respond(
+                    new ActionPayload(
+                        202,
+                        [
+                            'willBeDoneAt' => (new \DateTimeImmutable())->format(\DateTimeImmutable::ATOM)
+                        ]
+                    )
+                );
+            }
+        };
+
+        $app->get('/test-action-response-code', $testAction);
+        $request = $this->createRequest('GET', '/test-action-response-code');
+        $response = $app->handle($request);
+
+        $this->assertEquals(202, $response->getStatusCode());
+    }
+
+    public function testActionSetsHttpCodeRespondData()
+    {
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+        $logger = $container->get(LoggerInterface::class);
+
+        $testAction = new class($logger) extends Action {
+            public function __construct(
+                LoggerInterface $loggerInterface
+            ) {
+                parent::__construct($loggerInterface);
+            }
+
+            public function action() :Response
+            {
+                return $this->respondWithData(
+                    [
+                        'willBeDoneAt' => (new \DateTimeImmutable())->format(\DateTimeImmutable::ATOM)
+                    ],
+                    202
+                );
+            }
+        };
+
+        $app->get('/test-action-response-code', $testAction);
+        $request = $this->createRequest('GET', '/test-action-response-code');
+        $response = $app->handle($request);
+
+        $this->assertEquals(202, $response->getStatusCode());
+    }
+}

--- a/tests/Application/Actions/ActionTest.php
+++ b/tests/Application/Actions/ActionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Application\Actions;
 
 use App\Application\Actions\Action;
 use App\Application\Actions\ActionPayload;
+use DateTimeImmutable;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Log\LoggerInterface;
 use Tests\TestCase;
@@ -30,7 +31,7 @@ class ActionTest extends TestCase
                     new ActionPayload(
                         202,
                         [
-                            'willBeDoneAt' => (new \DateTimeImmutable())->format(\DateTimeImmutable::ATOM)
+                            'willBeDoneAt' => (new DateTimeImmutable())->format(DateTimeImmutable::ATOM)
                         ]
                     )
                 );
@@ -61,7 +62,7 @@ class ActionTest extends TestCase
             {
                 return $this->respondWithData(
                     [
-                        'willBeDoneAt' => (new \DateTimeImmutable())->format(\DateTimeImmutable::ATOM)
+                        'willBeDoneAt' => (new DateTimeImmutable())->format(DateTimeImmutable::ATOM)
                     ],
                     202
                 );


### PR DESCRIPTION
Currently when we pass a status code to the constructor of the ActionPayload class it is only used as a field in our json response. If we don't provide an error to the constructor, the HTTP code is always 200. It doesn't work for all scenarios. In some cases I would return the code 202 and provide information on when the action will be fully completed.