### PR TITLE
Enhancement: Require and use phpstan/extension-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     },
     "require-dev": {
         "jangregor/phpstan-prophecy": "^0.6.2",
+        "phpstan/extension-installer": "^1.0.4",
         "phpstan/phpstan": "^0.12.25",
         "phpunit/phpunit": "^8.5"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,2 @@
 parameters:
   level: 4
-includes:
-    - vendor/jangregor/phpstan-prophecy/src/extension.neon


### PR DESCRIPTION
This PR

* [x] requires and uses [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer)

Related to #165.

💁‍♂️ This should help with https://github.com/Jan0707/phpstan-prophecy/issues/179 and upgrading https://github.com/Jan0707/phpstan-prophecy/compare/0.6.2...0.8.0!