### PR TITLE
More appropriate in middleware.php since some middleware depend the order to add

### DIFF
--- a/app/middleware.php
+++ b/app/middleware.php
@@ -6,4 +6,5 @@ use Slim\App;
 
 return function (App $app) {
     $app->add(SessionMiddleware::class);
+    $app->addRoutingMiddleware();
 };

--- a/public/index.php
+++ b/public/index.php
@@ -60,9 +60,6 @@ $errorHandler = new HttpErrorHandler($callableResolver, $responseFactory);
 $shutdownHandler = new ShutdownHandler($request, $errorHandler, $displayErrorDetails);
 register_shutdown_function($shutdownHandler);
 
-// Add Routing Middleware
-$app->addRoutingMiddleware();
-
 // Add Error Middleware
 $errorMiddleware = $app->addErrorMiddleware($displayErrorDetails, false, false);
 $errorMiddleware->setDefaultErrorHandler($errorHandler);


### PR DESCRIPTION
When I tried to use Slim\Middleware\MethodOverrideMiddleware to overwrite HTTP method like PATCH, PUT or DELETE, it's required to be called **after** the call of addRoutingMiddleware. So it might be convenient this line is in middleware.php like the following for similar middleware.

```php
return function (App $app) {
    $app->add(SessionMiddleware::class);
    $app->addRoutingMiddleware();
    // this middleware should be called after added RoutingMiddleware
    $app->add(MethodOverrideMiddleware::class);
};
```