### PR TITLE
Allow PHP 8 usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "jangregor/phpstan-prophecy": "^0.8.1",
         "phpstan/extension-installer": "^1.1.0",
         "phpstan/phpstan": "^0.12.80",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "config": {
         "process-timeout": 0,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "monolog/monolog": "^2.2",
         "php-di/php-di": "^6.3",


### PR DESCRIPTION
Currently when installing via composer on a PHP 8 machine, this throws an error due to the PHP 7 requirement currently in place.