### PR TITLE
Error Handler status code improvement

### DIFF
--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -55,6 +55,7 @@ class HttpErrorHandler extends SlimErrorHandler
             && $exception instanceof Throwable
             && $this->displayErrorDetails
         ) {
+            $statusCode = $exception->getCode();
             $error->setDescription($exception->getMessage());
         }
 

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -55,7 +55,7 @@ class HttpErrorHandler extends SlimErrorHandler
             && $exception instanceof Throwable
             && $this->displayErrorDetails
         ) {
-            $statusCode = $exception->getCode();
+            $statusCode = ($exception->getCode()) ? $exception->getCode() : $statusCode;
             $error->setDescription($exception->getMessage());
         }
 


### PR DESCRIPTION
Added status code if an exception is not an instance of HttpExeception
to trigger error and see deference that it makes throw an error.
```php
 throw new Exception("This is a bad request", 400);
 // or
 throw new Exception("its not founded", 404);
```