### PR TITLE
Fix .htaccess syntax error in Apache

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
-+Options All –Indexes
+Options All -Indexes
 
 <Files .htaccess>
 order allow,deny

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,4 @@
-+Options All –Indexes
+Options All -Indexes
 
 <Files .htaccess>
 order allow,deny


### PR DESCRIPTION
The following error occurred in .htaccess on Apache. This pull request will fix that error.
Apache version: 2.4.48 (Debian) (Docker image php:7.4-apache)

- error: `Invalid command '+Options', perhaps misspelled or defined by a module not included in the server configuration`
  -> "+Options" is a mistake of "Options"
- error: `Illegal option \xe2\x80\x93Indexes`
  -> "–" is en dash(U+2013), not ascii