### PR TITLE
Fix optional type $description in ActionError can not be set to `null`

### DIFF
--- a/src/Application/Actions/ActionError.php
+++ b/src/Application/Actions/ActionError.php
@@ -22,7 +22,7 @@ class ActionError implements JsonSerializable
 
     private string $description;
 
-    public function __construct(string $type, ?string $description)
+    public function __construct(string $type, string $description)
     {
         $this->type = $type;
         $this->description = $description;
@@ -44,7 +44,7 @@ class ActionError implements JsonSerializable
         return $this->description;
     }
 
-    public function setDescription(?string $description = null): self
+    public function setDescription(string $description): self
     {
         $this->description = $description;
         return $this;

--- a/src/Application/Actions/ActionError.php
+++ b/src/Application/Actions/ActionError.php
@@ -22,7 +22,7 @@ class ActionError implements JsonSerializable
 
     private ?string $description;
 
-    public function __construct(string $type, ?string $description)
+    public function __construct(string $type, ?string $description = null)
     {
         $this->type = $type;
         $this->description = $description;
@@ -44,7 +44,7 @@ class ActionError implements JsonSerializable
         return $this->description;
     }
 
-    public function setDescription(?string $description): self
+    public function setDescription(?string $description = null): self
     {
         $this->description = $description;
         return $this;

--- a/src/Application/Actions/ActionError.php
+++ b/src/Application/Actions/ActionError.php
@@ -20,9 +20,9 @@ class ActionError implements JsonSerializable
 
     private string $type;
 
-    private string $description;
+    private ?string $description;
 
-    public function __construct(string $type, string $description)
+    public function __construct(string $type, ?string $description)
     {
         $this->type = $type;
         $this->description = $description;
@@ -39,12 +39,12 @@ class ActionError implements JsonSerializable
         return $this;
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    public function setDescription(string $description): self
+    public function setDescription(?string $description): self
     {
         $this->description = $description;
         return $this;


### PR DESCRIPTION
Please see this issue for context:
https://github.com/slimphp/Slim-Skeleton/issues/289