### PR TITLE
Fix deprecated string interpolation syntax

### DIFF
--- a/src/Application/Actions/User/ViewUserAction.php
+++ b/src/Application/Actions/User/ViewUserAction.php
@@ -16,7 +16,7 @@ class ViewUserAction extends UserAction
         $userId = (int) $this->resolveArg('id');
         $user = $this->userRepository->findUserOfId($userId);
 
-        $this->logger->info("User of id `${userId}` was viewed.");
+        $this->logger->info("User of id `{$userId}` was viewed.");
 
         return $this->respondWithData($user);
     }


### PR DESCRIPTION
This is a PR for issue #320.

Switch to a non-deprecated string interpolation syntax for PHP 8.2.