### PR TITLE
update php image version to 8-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
     slim:
-        image: php:7-alpine
+        image: php:8-alpine
         working_dir: /var/www
         command: php -S 0.0.0.0:8080 -t public
         environment:


### PR DESCRIPTION
You get an error if you try to run the skeleton app under php 7. Using `php:8-alpine` fixes it.