### PR TITLE
Fixed "ERROR: Using ${var} in strings is deprecated, use {$var} instead" and added logError and logErrorDetails variables on the Shutdown handler

### DIFF
--- a/src/Application/Actions/User/ViewUserAction.php
+++ b/src/Application/Actions/User/ViewUserAction.php
@@ -16,7 +16,7 @@ class ViewUserAction extends UserAction
         $userId = (int) $this->resolveArg('id');
         $user = $this->userRepository->findUserOfId($userId);
 
-        $this->logger->info("User of id `{$userId}` was viewed.");
+        $this->logger->info("User of id " . $userId . " was viewed.");
 
         return $this->respondWithData($user);
     }

--- a/src/Application/Handlers/ShutdownHandler.php
+++ b/src/Application/Handlers/ShutdownHandler.php
@@ -21,11 +21,11 @@ class ShutdownHandler
     private bool $logErrorDetails;
 
     public function __construct(
-        Request          $request,
+        Request $request,
         HttpErrorHandler $errorHandler,
-        bool             $displayErrorDetails,
-        bool             $logError,
-        bool             $logErrorDetails
+        bool $displayErrorDetails,
+        bool $logError,
+        bool $logErrorDetails
     ) {
         $this->request             = $request;
         $this->errorHandler        = $errorHandler;


### PR DESCRIPTION
Fixed php error on view user action (src\Application\Actions\User\ViewUserAction.php):

ERROR: Using ${var} in strings is deprecated, use {$var} instead"