### PR TITLE
set composer type to project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "router",
         "psr7"
     ],
+    "type": "project",
     "homepage": "http://github.com/slimphp/Slim-Skeleton",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This will cause it to be shown with the correct "prompt" on Packagist:

```sh
composer create-project slim/slim-skeleton
```